### PR TITLE
feat: expose modelOpen booleans from modal hooks

### DIFF
--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -21,9 +21,9 @@ type AccountStatus = ExtractString<ConnectButtonProps['accountStatus']>;
 type ChainStatus = ExtractString<ConnectButtonProps['chainStatus']>;
 
 const Example = () => {
-  const { openAccountModal } = useAccountModal();
-  const { openChainModal } = useChainModal();
-  const { openConnectModal } = useConnectModal();
+  const { accountModalOpen, openAccountModal } = useAccountModal();
+  const { chainModalOpen, openChainModal } = useChainModal();
+  const { connectModalOpen, openConnectModal } = useConnectModal();
 
   const { address, isConnected } = useAccount();
   const defaultProps = ConnectButton.__defaultProps;
@@ -221,8 +221,8 @@ const Example = () => {
 
       {isMounted && (
         <>
-          <div>
-            <h3 style={{ fontFamily: 'sans-serif' }}>Modal hooks</h3>
+          <div style={{ fontFamily: 'sans-serif' }}>
+            <h3>Modal hooks</h3>
             <div style={{ display: 'flex', gap: 12, paddingBottom: 12 }}>
               <button
                 disabled={!openConnectModal}
@@ -245,6 +245,11 @@ const Example = () => {
               >
                 Open account modal
               </button>
+            </div>
+            <div>
+              {connectModalOpen && <div>Connect modal open</div>}
+              {chainModalOpen && <div>Chain modal open</div>}
+              {accountModalOpen && <div>Account modal open</div>}
             </div>
           </div>
 

--- a/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
@@ -116,16 +116,16 @@ export function useModalState() {
 }
 
 export function useAccountModal() {
-  const { openAccountModal } = useContext(ModalContext);
-  return { openAccountModal };
+  const { accountModalOpen, openAccountModal } = useContext(ModalContext);
+  return { accountModalOpen, openAccountModal };
 }
 
 export function useChainModal() {
-  const { openChainModal } = useContext(ModalContext);
-  return { openChainModal };
+  const { chainModalOpen, openChainModal } = useContext(ModalContext);
+  return { chainModalOpen, openChainModal };
 }
 
 export function useConnectModal() {
-  const { openConnectModal } = useContext(ModalContext);
-  return { openConnectModal };
+  const { connectModalOpen, openConnectModal } = useContext(ModalContext);
+  return { connectModalOpen, openConnectModal };
 }


### PR DESCRIPTION
ConnectButton.Custom exposes accountModalOpen, chainModalOpen, and connectModalOpen. This adds each to their respective hooks for feature parity.

```
const { connectModalOpen, openConnectModal } = useConnectModal();
const { accountModalOpen, openAccountModal } = useAccountModal();
const { chainModelOpen, openChainModal } = useChainModal();
```

Includes a demo line in the example page as well
<img width="949" alt="image" src="https://user-images.githubusercontent.com/5885679/181092067-17de9375-fab4-44fc-97ba-78b49f4de1e6.png">